### PR TITLE
Get rid of the urlgrabber dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(name='osc2',
       cmdclass={'build': BuildDocumentation},
       install_requires=[
           "lxml",
-          "urlgrabber",
           "jinja2"
       ],
       classifiers=["Programming Language :: Python :: 2.7"])


### PR DESCRIPTION
This is a prerequisite for the upcoming python3 port because the
urlgrabber module is not python3 compatible. Actually, not inheriting
from the urlgrabber.mirror.MirrorGroup class makes the code much more
concise.